### PR TITLE
Hotfix/image

### DIFF
--- a/src/main/java/com/artfolio/artfolio/domain/ArtPiecePhoto.java
+++ b/src/main/java/com/artfolio/artfolio/domain/ArtPiecePhoto.java
@@ -23,17 +23,21 @@ public class ArtPiecePhoto {
     @Column(nullable = false)
     private Long size;
 
+    @Column(nullable = false)
+    private Boolean isThumbnail;
+
     @Setter
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "art_piece_id", nullable = false)
     private ArtPiece artPiece;
 
     @Builder
-    public ArtPiecePhoto(String fileName, String fileExtension, String filePath, Long size, ArtPiece artPiece) {
+    public ArtPiecePhoto(String fileName, String fileExtension, String filePath, Long size, Boolean isThumbnail, ArtPiece artPiece) {
         this.fileName = fileName;
         this.fileExtension = fileExtension;
         this.filePath = filePath;
         this.size = size;
+        this.isThumbnail = isThumbnail;
         this.artPiece = artPiece;
     }
 }

--- a/src/main/java/com/artfolio/artfolio/dto/RealTimeAuctionInfo.java
+++ b/src/main/java/com/artfolio/artfolio/dto/RealTimeAuctionInfo.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ public class RealTimeAuctionInfo { // Data transfer Object
     @Id @JsonProperty("auctionId")
     private String id;
     private Long artistId;                           // 작가 ID
-    private Long artPieceId;                         // 예술품 ID
+    @Indexed private Long artPieceId;                         // 예술품 ID
     private String artPieceTitle;                    // 예술품 제목
     private String auctionTitle;                     // 경매 제목
     private String auctionContent;                   // 경매 설명글
@@ -37,4 +38,7 @@ public class RealTimeAuctionInfo { // Data transfer Object
     private Set<Long> likeMembers = new HashSet<>();       // 좋아요 누른 멤버 ID 목록
     private List<String> photoPaths = new ArrayList<>();   // 사진 경로
 
+    public void updateAuctionPhoto(String photoPath) {
+        this.photoPaths.add(photoPath);
+    }
 }

--- a/src/main/java/com/artfolio/artfolio/dto/RealTimeAuctionPreviewRes.java
+++ b/src/main/java/com/artfolio/artfolio/dto/RealTimeAuctionPreviewRes.java
@@ -9,15 +9,15 @@ public record RealTimeAuctionPreviewRes(
         Integer dataSize,
         List<PreviewInfo> data
 ) {
-    public static RealTimeAuctionPreviewRes of(Integer pageSize, Integer pageNumber, List<PreviewInfo> infos) {
-        int size = infos.size();
+    public static RealTimeAuctionPreviewRes of(Integer pageSize, Integer pageNumber, List<PreviewInfo> data) {
+        int size = data.size();
 
         return new RealTimeAuctionPreviewRes(
                 size == 0,
                 pageSize,
                 pageNumber,
                 size,
-                infos
+                data
         );
     }
 
@@ -29,14 +29,14 @@ public record RealTimeAuctionPreviewRes(
             String artPieceTitle,
             String thumbnailPath
     ) {
-        public static PreviewInfo of(RealTimeAuctionInfo info) {
+        public static PreviewInfo of(RealTimeAuctionInfo info, String thumbnailPath) {
             return new PreviewInfo(
                     info.getId(),
                     info.getLike(),
                     info.getAuctionCurrentPrice(),
                     info.getAuctionTitle(),
                     info.getArtPieceTitle(),
-                    info.getPhotoPaths().size() == 0 ? "null" : info.getPhotoPaths().get(0)
+                    thumbnailPath
             );
         }
     }

--- a/src/main/java/com/artfolio/artfolio/error/AuctionErrorHandlingController.java
+++ b/src/main/java/com/artfolio/artfolio/error/AuctionErrorHandlingController.java
@@ -1,5 +1,6 @@
 package com.artfolio.artfolio.error;
 
+import com.artfolio.artfolio.exception.AuctionAlreadyExistsException;
 import com.artfolio.artfolio.exception.AuctionAlreadyFinishedException;
 import com.artfolio.artfolio.exception.AuctionNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -49,5 +50,13 @@ public class AuctionErrorHandlingController {
     protected ErrorResponse handleAuctionAlreadyFinishedException(AuctionAlreadyFinishedException e) {
         log.error("이미 종료된 경매 건입니다. auction ID : " + e.getAuctionId());
         return buildError(ErrorCode.AUCTION_ALREADY_FINISHED);
+    }
+
+    /* 예술품에 대해 진행중인 경매가 이미 있는데 동일한 예술품 ID로 새 경매를 생성하는 경우 예외 처리 */
+    @ExceptionHandler(AuctionAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ErrorResponse handleAuctionAlreadyExistsException(AuctionAlreadyExistsException e) {
+        log.error("해당 예술품에 이미 진행중인 경매가 존재합니다. artPiece ID : " + e.getArtPieceId());
+        return buildError(ErrorCode.AUCTION_ALREADY_EXISTS);
     }
 }

--- a/src/main/java/com/artfolio/artfolio/error/ErrorCode.java
+++ b/src/main/java/com/artfolio/artfolio/error/ErrorCode.java
@@ -7,9 +7,10 @@ public enum ErrorCode {
     INPUT_VALUE_INVALID("INPUT_VALUE_INVALID", "데이터 형식이 맞지 않습니다.", 400),
     AUCTION_NOT_FOUND("AUCTION_NOT_FOUND", "해당 경매를 찾을 수 없습니다.", 400),
     AUCTION_ALREADY_FINISHED("AUCTION_ALREADY_FINISHED", "이미 종료된 경매 건입니다.", 400),
+    AUCTION_ALREADY_EXISTS("AUCTION_ALREADY_EXISTS", "해당 예술품이 이미 경매 진행 중입니다.", 400),
     ARTPIECE_NOT_FOUND("ARTPIECE_NOT_FOUND", "해당 예술품을 찾을 수 없습니다.", 400),
     MEMBER_NOT_FOUND("MEMBER_NOT_FOUND", "해당 예술가를 찾을 수 없습니다.", 400),
-    NO_DELETE_AUTHORITY("NO_DELETE_AUTHORITY", "삭제 권한이 없습니다.", 400)
+    NO_DELETE_AUTHORITY("NO_DELETE_AUTHORITY", "삭제 권한이 없습니다.", 400),
     ;
 
     private final String code;

--- a/src/main/java/com/artfolio/artfolio/exception/AuctionAlreadyExistsException.java
+++ b/src/main/java/com/artfolio/artfolio/exception/AuctionAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.artfolio.artfolio.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuctionAlreadyExistsException extends RuntimeException {
+    private final Long artPieceId;
+
+    public AuctionAlreadyExistsException(Long artPieceId) {
+        this.artPieceId = artPieceId;
+    }
+}

--- a/src/main/java/com/artfolio/artfolio/repository/RealTimeAuctionRedisRepository.java
+++ b/src/main/java/com/artfolio/artfolio/repository/RealTimeAuctionRedisRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface RealTimeAuctionRedisRepository extends CrudRepository<RealTimeAuctionInfo, String> {
     List<RealTimeAuctionInfo> findAll(Pageable pageable);
+    Optional<RealTimeAuctionInfo> findByArtPieceId(Long artPieceId);
 }

--- a/src/main/java/com/artfolio/artfolio/service/ImageService.java
+++ b/src/main/java/com/artfolio/artfolio/service/ImageService.java
@@ -59,9 +59,9 @@ public class ImageService {
                         .build();
 
                 photos.add(entity);
-            } else {
-                realTimeAuctionService.updateThumbnailImage(artPieceId, s3Path);
             }
+
+            realTimeAuctionService.updateImage(artPieceId, s3Path);
         }
 
         // 로컬 경로 내 모든 사진 삭제

--- a/src/main/java/com/artfolio/artfolio/service/ImageService.java
+++ b/src/main/java/com/artfolio/artfolio/service/ImageService.java
@@ -22,14 +22,15 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Service
 public class ImageService {
-    private final ArtPiecePhotoRepository artPiecePhotoRepository;
-    private final ArtPieceRepository artPieceRepository;
-    private final S3Uploader s3Uploader;
     private static final String DEFAULT_IMAGE_DIR = System.getProperty("user.dir")
             + "/src/main/resources/images";
+    private final ArtPiecePhotoRepository artPiecePhotoRepository;
+    private final ArtPieceRepository artPieceRepository;
+    private final RealTimeAuctionService realTimeAuctionService;
+    private final S3Uploader s3Uploader;
+    private String thumbnailFileName;
 
     public Long uploadImage(Long artPieceId, MultipartFile[] files) {
-
         ArtPiece artPiece = artPieceRepository.findById(artPieceId)
                 .orElseThrow(() -> new ArtPieceNotFoundException(artPieceId));
 
@@ -53,16 +54,23 @@ public class ImageService {
                         .filePath(s3Path)
                         .fileExtension(ext)
                         .size(img.length())
+                        .isThumbnail(fileName.equals(thumbnailFileName))
                         .artPiece(artPiece)
                         .build();
 
                 photos.add(entity);
+            } else {
+                realTimeAuctionService.updateThumbnailImage(artPieceId, s3Path);
             }
+        }
 
+        // 로컬 경로 내 모든 사진 삭제
+        for (File img : Objects.requireNonNull(imgDir.listFiles())) {
             img.delete();
         }
 
         artPiecePhotoRepository.saveAll(photos);
+
         return 1L;
     }
 
@@ -86,6 +94,7 @@ public class ImageService {
                 if (isFirst) {
                     ImageUtil.imageResize(DEFAULT_IMAGE_DIR, fileName, ext);
                     isFirst = false;
+                    thumbnailFileName = fileName;
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     defer-datasource-initialization: true   # data.sql이 하이버네이트 초기화 이후 실행하도록 설정하는 옵션
-    hibernate.ddl-auto: update
+    hibernate.ddl-auto: create
     open-in-view: false
     show-sql: true
     properties:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -32,4 +32,4 @@ insert into art_piece values(26, now(), 'seungsu', '게시글 26번', 37, '상�
 insert into art_piece values(27, now(), 'seungsu', '게시글 27번', 27, '상세글 27번', 1);
 insert into art_piece values(28, now(), 'seungsu', '게시글 28번', 17, '상세글 28번', 2);
 insert into art_piece values(29, now(), 'seungsu', '게시글 29번', 10, '상세글 29번', 1);
-insert into art_piece values(30, now(), 'seungsu', '게시글 39번', 1, '상세글 30번', 2);
+insert into art_piece values(30, now(), 'seungsu', '게시글 30번', 1, '상세글 30번', 2);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,35 @@
+insert into member values (1, '작가 황승수입니다.', 'aaa@aa.com', true, 111, '황승수', 'null');
+insert into member values (2, '작가 이지영입니다.', 'bbb@bb.com', true, 222, '이지영', 'null');
+
+insert into art_piece values(1, now(), 'seungsu', '게시글 1번', 10, '상세글 1번', 1);
+insert into art_piece values(2, now(), 'seungsu', '게시글 2번', 20, '상세글 2번', 2);
+insert into art_piece values(3, now(), 'seungsu', '게시글 3번', 30, '상세글 3번', 1);
+insert into art_piece values(4, now(), 'seungsu', '게시글 4번', 40, '상세글 4번', 2);
+insert into art_piece values(5, now(), 'seungsu', '게시글 5번', 50, '상세글 5번', 1);
+insert into art_piece values(6, now(), 'seungsu', '게시글 6번', 40, '상세글 6번', 2);
+insert into art_piece values(7, now(), 'seungsu', '게시글 7번', 30, '상세글 7번', 1);
+insert into art_piece values(8, now(), 'seungsu', '게시글 8번', 20, '상세글 8번', 2);
+insert into art_piece values(9, now(), 'seungsu', '게시글 9번', 10, '상세글 9번', 1);
+insert into art_piece values(10, now(), 'seungsu', '게시글 10번', 15, '상세글 10번', 2);
+
+insert into art_piece values(11, now(), 'seungsu', '게시글 11번', 25, '상세글 11번', 1);
+insert into art_piece values(12, now(), 'seungsu', '게시글 12번', 35, '상세글 12번', 2);
+insert into art_piece values(13, now(), 'seungsu', '게시글 13번', 45, '상세글 13번', 1);
+insert into art_piece values(14, now(), 'seungsu', '게시글 14번', 55, '상세글 14번', 2);
+insert into art_piece values(15, now(), 'seungsu', '게시글 15번', 65, '상세글 15번', 1);
+insert into art_piece values(16, now(), 'seungsu', '게시글 16번', 55, '상세글 16번', 2);
+insert into art_piece values(17, now(), 'seungsu', '게시글 17번', 45, '상세글 17번', 1);
+insert into art_piece values(18, now(), 'seungsu', '게시글 18번', 35, '상세글 18번', 2);
+insert into art_piece values(19, now(), 'seungsu', '게시글 19번', 25, '상세글 19번', 1);
+insert into art_piece values(20, now(), 'seungsu', '게시글 20번', 15, '상세글 20번', 2);
+
+insert into art_piece values(21, now(), 'seungsu', '게시글 21번', 7, '상세글 21번', 1);
+insert into art_piece values(22, now(), 'seungsu', '게시글 22번', 17, '상세글 22번', 2);
+insert into art_piece values(23, now(), 'seungsu', '게시글 23번', 27, '상세글 23번', 1);
+insert into art_piece values(24, now(), 'seungsu', '게시글 24번', 37, '상세글 24번', 2);
+insert into art_piece values(25, now(), 'seungsu', '게시글 25번', 47, '상세글 25번', 1);
+insert into art_piece values(26, now(), 'seungsu', '게시글 26번', 37, '상세글 26번', 2);
+insert into art_piece values(27, now(), 'seungsu', '게시글 27번', 27, '상세글 27번', 1);
+insert into art_piece values(28, now(), 'seungsu', '게시글 28번', 17, '상세글 28번', 2);
+insert into art_piece values(29, now(), 'seungsu', '게시글 29번', 10, '상세글 29번', 1);
+insert into art_piece values(30, now(), 'seungsu', '게시글 39번', 1, '상세글 30번', 2);


### PR DESCRIPTION
1. 프론트 테스트용 더미 데이터 추가

2. 진행중인 경매에 대해 이미지 전달 방식 로직 수정
- 경매 페이지 상세보기에서는 압축된 사진 경로를 뺀 리스트를 전달해주어야 함
- 경매 페이지 미리보기에서는 압축된 사진 경로 1개만 필터링해서 전달해주어야 함

3. 동일한 예술품 ID로 경매를 생성하는 경우 예외 처리 로직 추가